### PR TITLE
Remove overflow on search

### DIFF
--- a/lib/bottom_sheet/multi_select_bottom_sheet.dart
+++ b/lib/bottom_sheet/multi_select_bottom_sheet.dart
@@ -207,8 +207,7 @@ class _MultiSelectBottomSheetState<V> extends State<MultiSelectBottomSheet<V>> {
   @override
   Widget build(BuildContext context) {
     return Container(
-      padding:
-          EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
+      
       child: DraggableScrollableSheet(
         initialChildSize: widget.initialChildSize ?? 0.3,
         minChildSize: widget.minChildSize ?? 0.3,


### PR DESCRIPTION
This padding cause overflow when the keyboard is opened while searching
```padding:
          EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
```