### PR TITLE
Fix selectedItemsTextStyle not working properly with GoogleFonts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.1.9] - 2021-09-23
+### Fixed
+- selectedItemsTextStyle not configured properly in ChoiceChip
 
 ## [3.1.8] - 2021-02-15
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Multi Select Flutter is a package for creating multi-select widgets in a variety
 Add this to your pubspec.yaml file:
 ```yaml
 dependencies:
-  multi_select_flutter: ^3.1.8
+  multi_select_flutter: ^3.1.9
 ```
 
 ## Usage

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -80,7 +80,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   multi_select_flutter:
     dependency: "direct main"
     description:
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:
@@ -157,4 +157,4 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/lib/bottom_sheet/multi_select_bottom_sheet.dart
+++ b/lib/bottom_sheet/multi_select_bottom_sheet.dart
@@ -210,27 +210,6 @@ class _MultiSelectBottomSheetState<V> extends State<MultiSelectBottomSheet<V>> {
                           : null,
                     )
               : widget.itemsTextStyle,
-          // style: _selectedValues.contains(item.value)
-          //     ? TextStyle(
-          //         color: widget.colorator != null &&
-          //                 widget.colorator!(item.value) != null
-          //             ? widget.selectedItemsTextStyle != null
-          //                 ? widget.selectedItemsTextStyle!.color ??
-          //                     widget.colorator!(item.value)!.withOpacity(1)
-          //                 : widget.colorator!(item.value)!.withOpacity(1)
-          //             : widget.selectedItemsTextStyle != null
-          //                 ? widget.selectedItemsTextStyle!.color ??
-          //                     (widget.selectedColor != null
-          //                         ? widget.selectedColor!.withOpacity(1)
-          //                         : Theme.of(context).primaryColor)
-          //                 : widget.selectedColor != null
-          //                     ? widget.selectedColor!.withOpacity(1)
-          //                     : null,
-          //         fontSize: widget.selectedItemsTextStyle != null
-          //             ? widget.selectedItemsTextStyle!.fontSize
-          //             : null,
-          //       )
-          //     : widget.itemsTextStyle,
         ),
         selected: _selectedValues.contains(item.value),
         onSelected: (checked) {

--- a/lib/bottom_sheet/multi_select_bottom_sheet.dart
+++ b/lib/bottom_sheet/multi_select_bottom_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
-import '../util/multi_select_item.dart';
+
 import '../util/multi_select_actions.dart';
+import '../util/multi_select_item.dart';
 import '../util/multi_select_list_type.dart';
 
 /// A bottom sheet widget containing either a classic checkbox style list, or a chip style list.
@@ -169,26 +170,67 @@ class _MultiSelectBottomSheetState<V> extends State<MultiSelectBottomSheet<V>> {
         label: Text(
           item.label,
           style: _selectedValues.contains(item.value)
-              ? TextStyle(
-                  color: widget.colorator != null &&
-                          widget.colorator!(item.value) != null
-                      ? widget.selectedItemsTextStyle != null
-                          ? widget.selectedItemsTextStyle!.color ??
-                              widget.colorator!(item.value)!.withOpacity(1)
-                          : widget.colorator!(item.value)!.withOpacity(1)
-                      : widget.selectedItemsTextStyle != null
-                          ? widget.selectedItemsTextStyle!.color ??
-                              (widget.selectedColor != null
+              ? widget.selectedItemsTextStyle != null
+                  ? widget.selectedItemsTextStyle!.copyWith(
+                      color: widget.colorator != null &&
+                              widget.colorator!(item.value) != null
+                          ? widget.selectedItemsTextStyle != null
+                              ? widget.selectedItemsTextStyle!.color ??
+                                  widget.colorator!(item.value)!.withOpacity(1)
+                              : widget.colorator!(item.value)!.withOpacity(1)
+                          : widget.selectedItemsTextStyle != null
+                              ? widget.selectedItemsTextStyle!.color ??
+                                  (widget.selectedColor != null
+                                      ? widget.selectedColor!.withOpacity(1)
+                                      : Theme.of(context).primaryColor)
+                              : widget.selectedColor != null
                                   ? widget.selectedColor!.withOpacity(1)
-                                  : Theme.of(context).primaryColor)
-                          : widget.selectedColor != null
-                              ? widget.selectedColor!.withOpacity(1)
-                              : null,
-                  fontSize: widget.selectedItemsTextStyle != null
-                      ? widget.selectedItemsTextStyle!.fontSize
-                      : null,
-                )
+                                  : null,
+                      fontSize: widget.selectedItemsTextStyle != null
+                          ? widget.selectedItemsTextStyle!.fontSize
+                          : null,
+                    )
+                  : TextStyle(
+                      color: widget.colorator != null &&
+                              widget.colorator!(item.value) != null
+                          ? widget.selectedItemsTextStyle != null
+                              ? widget.selectedItemsTextStyle!.color ??
+                                  widget.colorator!(item.value)!.withOpacity(1)
+                              : widget.colorator!(item.value)!.withOpacity(1)
+                          : widget.selectedItemsTextStyle != null
+                              ? widget.selectedItemsTextStyle!.color ??
+                                  (widget.selectedColor != null
+                                      ? widget.selectedColor!.withOpacity(1)
+                                      : Theme.of(context).primaryColor)
+                              : widget.selectedColor != null
+                                  ? widget.selectedColor!.withOpacity(1)
+                                  : null,
+                      fontSize: widget.selectedItemsTextStyle != null
+                          ? widget.selectedItemsTextStyle!.fontSize
+                          : null,
+                    )
               : widget.itemsTextStyle,
+          // style: _selectedValues.contains(item.value)
+          //     ? TextStyle(
+          //         color: widget.colorator != null &&
+          //                 widget.colorator!(item.value) != null
+          //             ? widget.selectedItemsTextStyle != null
+          //                 ? widget.selectedItemsTextStyle!.color ??
+          //                     widget.colorator!(item.value)!.withOpacity(1)
+          //                 : widget.colorator!(item.value)!.withOpacity(1)
+          //             : widget.selectedItemsTextStyle != null
+          //                 ? widget.selectedItemsTextStyle!.color ??
+          //                     (widget.selectedColor != null
+          //                         ? widget.selectedColor!.withOpacity(1)
+          //                         : Theme.of(context).primaryColor)
+          //                 : widget.selectedColor != null
+          //                     ? widget.selectedColor!.withOpacity(1)
+          //                     : null,
+          //         fontSize: widget.selectedItemsTextStyle != null
+          //             ? widget.selectedItemsTextStyle!.fontSize
+          //             : null,
+          //       )
+          //     : widget.itemsTextStyle,
         ),
         selected: _selectedValues.contains(item.value),
         onSelected: (checked) {

--- a/lib/chip_display/multi_select_chip_display.dart
+++ b/lib/chip_display/multi_select_chip_display.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+
 import '../util/horizontal_scrollbar.dart';
 import '../util/multi_select_item.dart';
 
@@ -144,18 +145,31 @@ class MultiSelectChipDisplay<V> extends StatelessWidget {
           child: Text(
             item.label,
             overflow: TextOverflow.ellipsis,
-            style: TextStyle(
-              color: colorator != null && colorator!(item.value) != null
-                  ? textStyle != null
-                      ? textStyle!.color ?? colorator!(item.value)
-                      : colorator!(item.value)
-                  : textStyle != null && textStyle!.color != null
-                      ? textStyle!.color
-                      : chipColor != null
-                          ? chipColor!.withOpacity(1)
-                          : null,
-              fontSize: textStyle != null ? textStyle!.fontSize : null,
-            ),
+            style: textStyle != null
+                ? textStyle!.copyWith(
+                    color: colorator != null && colorator!(item.value) != null
+                        ? textStyle != null
+                            ? textStyle!.color ?? colorator!(item.value)
+                            : colorator!(item.value)
+                        : textStyle != null && textStyle!.color != null
+                            ? textStyle!.color
+                            : chipColor != null
+                                ? chipColor!.withOpacity(1)
+                                : null,
+                    fontSize: textStyle != null ? textStyle!.fontSize : null,
+                  )
+                : TextStyle(
+                    color: colorator != null && colorator!(item.value) != null
+                        ? textStyle != null
+                            ? textStyle!.color ?? colorator!(item.value)
+                            : colorator!(item.value)
+                        : textStyle != null && textStyle!.color != null
+                            ? textStyle!.color
+                            : chipColor != null
+                                ? chipColor!.withOpacity(1)
+                                : null,
+                    fontSize: textStyle != null ? textStyle!.fontSize : null,
+                  ),
           ),
         ),
         selected: items!.contains(item),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -28,7 +28,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -73,7 +73,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -92,7 +92,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.2"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
Previous selectedItemsTextStyle setup only copy with color and font size for text style. It doesn't work when you use GoogleFonts for text style configuration. This request is to fix the selectedItemsTextStyle setup under ChoiceChip widget. 