### PR TITLE
Fix #12 change selected items programmatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ MultiSelectDialogField has all the parameters of MultiSelectDialog plus these ex
 | `barrierColor` | Color | Set the color of the space outside the dialog. |
 | `buttonText` | Text | Set text that is displayed on the button. |
 | `buttonIcon` | Icon | Specify the button icon. |
+| `controller` | MultiSelectDialogFieldController\<V> | Set a controller which allows you to handle the list programmatically. |
 | `chipDisplay` | MultiSelectChipDisplay | Override the default MultiSelectChipDisplay that belongs to this field. |
 | `decoration` | BoxDecoration | Style the Container that makes up the field. |
 | `key` | GlobalKey\<FormFieldState> | Access FormFieldState methods. |

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:multi_select_flutter/multi_select_flutter.dart';
+import 'package:multi_select_flutter/util/multi_select_dialog_field_controller.dart';
 
 void main() {
   runApp(MyApp());
@@ -66,19 +67,19 @@ class _MyHomePageState extends State<MyHomePage> {
     Animal(id: 26, name: "Dragonfly"),
     Animal(id: 27, name: "Dolphin"),
   ];
-  final _items = _animals
-      .map((animal) => MultiSelectItem<Animal>(animal, animal.name))
-      .toList();
-  //List<Animal> _selectedAnimals = [];
-  List<Animal> _selectedAnimals2 = [];
-  List<Animal> _selectedAnimals3 = [];
-  //List<Animal> _selectedAnimals4 = [];
-  List<Animal> _selectedAnimals5 = [];
+  final _items = _animals.map((animal) => MultiSelectItem<Animal>(animal, animal.name)).toList();
   final _multiSelectKey = GlobalKey<FormFieldState>();
+
+  MultiSelectDialogFieldController<Animal> controller = MultiSelectDialogFieldController<Animal>();
+  MultiSelectDialogFieldController<Animal> controller2 = MultiSelectDialogFieldController<Animal>();
+  MultiSelectDialogFieldController<Animal> controller3 = MultiSelectDialogFieldController<Animal>();
+  MultiSelectDialogFieldController<Animal> controller4 = MultiSelectDialogFieldController<Animal>();
+  MultiSelectDialogFieldController<Animal> controller5 = MultiSelectDialogFieldController<Animal>();
+  List<Animal> _animals5 = [];
 
   @override
   void initState() {
-    _selectedAnimals5 = _animals;
+    _animals5 = _animals.toList();
     super.initState();
   }
 
@@ -98,8 +99,9 @@ class _MyHomePageState extends State<MyHomePage> {
               //################################################################################################
               // Rounded blue MultiSelectDialogField
               //################################################################################################
-              MultiSelectDialogField(
+              MultiSelectDialogField<Animal>(
                 items: _items,
+                controller: controller,
                 title: Text("Animals"),
                 selectedColor: Colors.blue,
                 decoration: BoxDecoration(
@@ -121,9 +123,19 @@ class _MyHomePageState extends State<MyHomePage> {
                     fontSize: 16,
                   ),
                 ),
-                onConfirm: (results) {
-                  //_selectedAnimals = results;
-                },
+                chipDisplay: MultiSelectChipDisplay<Animal>(),
+              ),
+              ButtonBar(
+                children: [
+                  ElevatedButton(
+                    onPressed: () {
+                      setState(() {
+                        controller.selectedItems.clear();
+                      });
+                    },
+                    child: Text("Clear selection"),
+                  ),
+                ],
               ),
               SizedBox(height: 50),
               //################################################################################################
@@ -140,25 +152,27 @@ class _MyHomePageState extends State<MyHomePage> {
                 ),
                 child: Column(
                   children: <Widget>[
-                    MultiSelectBottomSheetField(
+                    MultiSelectBottomSheetField<Animal>(
                       initialChildSize: 0.4,
                       listType: MultiSelectListType.CHIP,
                       searchable: true,
                       buttonText: Text("Favorite Animals"),
                       title: Text("Animals"),
                       items: _items,
-                      onConfirm: (values) {
-                        _selectedAnimals2 = values;
+                      onConfirm: (List<Animal> values) {
+                        setState(() {
+                          controller2.selectedItems = values;
+                        });
                       },
                       chipDisplay: MultiSelectChipDisplay(
                         onTap: (value) {
                           setState(() {
-                            _selectedAnimals2.remove(value);
+                            controller2.selectedItems.remove(value);
                           });
                         },
                       ),
                     ),
-                    _selectedAnimals2 == null || _selectedAnimals2.isEmpty
+                    controller2.selectedItems == null || controller2.selectedItems.isEmpty
                         ? Container(
                             padding: EdgeInsets.all(10),
                             alignment: Alignment.centerLeft,
@@ -194,14 +208,14 @@ class _MyHomePageState extends State<MyHomePage> {
                 },
                 onConfirm: (values) {
                   setState(() {
-                    _selectedAnimals3 = values;
+                    controller3.selectedItems = values;
                   });
                   _multiSelectKey.currentState.validate();
                 },
                 chipDisplay: MultiSelectChipDisplay(
                   onTap: (item) {
                     setState(() {
-                      _selectedAnimals3.remove(item);
+                      controller3.selectedItems.remove(item);
                     });
                     _multiSelectKey.currentState.validate();
                   },
@@ -211,7 +225,7 @@ class _MyHomePageState extends State<MyHomePage> {
               //################################################################################################
               // MultiSelectChipField
               //################################################################################################
-              MultiSelectChipField(
+              MultiSelectChipField<Animal>(
                 items: _items,
                 initialValue: [_animals[4], _animals[7], _animals[9]],
                 title: Text("Animals"),
@@ -229,13 +243,11 @@ class _MyHomePageState extends State<MyHomePage> {
               //################################################################################################
               // MultiSelectDialogField with initial values
               //################################################################################################
-              MultiSelectDialogField(
-                onConfirm: (val) {
-                  _selectedAnimals5 = val;
-                },
+              MultiSelectDialogField<Animal>(
                 items: _items,
-                initialValue:
-                    _selectedAnimals5, // setting the value of this in initState() to pre-select values.
+                // controller: controller5,
+                // setting the value of this in initState() to pre-select values.
+                initialValue: _animals5,
               ),
             ],
           ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -244,10 +244,11 @@ class _MyHomePageState extends State<MyHomePage> {
               // MultiSelectDialogField with initial values
               //################################################################################################
               MultiSelectDialogField<Animal>(
+                // the controller here is not used
                 items: _items,
-                // controller: controller5,
                 // setting the value of this in initState() to pre-select values.
                 initialValue: _animals5,
+                chipDisplay: MultiSelectChipDisplay<Animal>(),
               ),
             ],
           ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -84,10 +84,10 @@ packages:
   multi_select_flutter:
     dependency: "direct main"
     description:
-      name: multi_select_flutter
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.1.7"
+      path: ".."
+      relative: true
+    source: path
+    version: "3.1.8"
   path:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,7 +13,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  multi_select_flutter: ^3.1.7
+  multi_select_flutter:
+    path: ../
 
 
   # The following adds the Cupertino Icons font to your application.

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -5,10 +5,9 @@
 // gestures. You can also use WidgetTester to find child widgets in the widget
 // tree, read text, and verify that the values of widget properties are correct.
 
+import 'package:example/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-import 'package:example/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/lib/bottom_sheet/multi_select_bottom_sheet_field.dart
+++ b/lib/bottom_sheet/multi_select_bottom_sheet_field.dart
@@ -389,7 +389,7 @@ class __MultiSelectBottomSheetFieldViewState<V>
             cancelText: widget.cancelText,
             confirmText: widget.confirmText,
             initialValue: _selectedItems,
-            onConfirm: (selected) {
+            onConfirm: (List<V> selected) {
               if (widget.state != null) {
                 widget.state!.didChange(selected);
               }

--- a/lib/dialog/multi_select_dialog_field.dart
+++ b/lib/dialog/multi_select_dialog_field.dart
@@ -97,6 +97,9 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
   final GlobalKey<FormFieldState>? key;
   FormFieldState<List<V>>? state;
 
+  /// Controller for programmatically change selected items
+  final MultiSelectDialogFieldController controller;
+
   MultiSelectDialogField({
     required this.items,
     required this.onConfirm,
@@ -128,6 +131,7 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
     this.validator,
     this.initialValue,
     this.autovalidateMode = AutovalidateMode.disabled,
+    this.controller,
     this.key,
   }) : super(
             key: key,
@@ -166,7 +170,8 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
                 selectedItemsTextStyle: selectedItemsTextStyle,
                 checkColor: checkColor,
               );
-              return _MultiSelectDialogFieldView<V?>._withState(field as _MultiSelectDialogFieldView<V?>, state);
+              return _MultiSelectDialogFieldView<V?>._withState(
+                  field as _MultiSelectDialogFieldView<V?>, state);
             });
 }
 
@@ -200,6 +205,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
   final TextStyle? searchHintStyle;
   final Color? checkColor;
   FormFieldState<List<V>>? state;
+  final MultiSelectDialogFieldController controller;
 
   _MultiSelectDialogFieldView({
     required this.items,
@@ -229,6 +235,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
     this.searchHintStyle,
     this.selectedItemsTextStyle,
     this.checkColor,
+    this.controller,
   });
 
   /// This constructor allows a FormFieldState to be passed in. Called by MultiSelectDialogField.
@@ -261,6 +268,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
         searchTextStyle = field.searchTextStyle,
         selectedItemsTextStyle = field.selectedItemsTextStyle,
         checkColor = field.checkColor,
+        controller = field.controller,
         state = state;
 
   @override
@@ -270,20 +278,18 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
 
 class __MultiSelectDialogFieldViewState<V>
     extends State<_MultiSelectDialogFieldView<V>> {
-  List<V> _selectedItems = [];
-
   void initState() {
     super.initState();
     if (widget.initialValue != null) {
-      _selectedItems.addAll(widget.initialValue!);
+      widget.controller.selectedItems.addAll(widget.initialValue!);
     }
   }
 
   Widget _buildInheritedChipDisplay() {
     List<MultiSelectItem<V>?> chipDisplayItems = [];
-    chipDisplayItems = _selectedItems
-        .map((e) => widget.items
-            .firstWhereOrNull((element) => e == element.value))
+    chipDisplayItems = widget.controller.selectedItems
+        .map((e) =>
+            widget.items.firstWhereOrNull((element) => e == element.value))
         .toList();
     chipDisplayItems.removeWhere((element) => element == null);
     if (widget.chipDisplay != null) {
@@ -301,9 +307,9 @@ class __MultiSelectDialogFieldViewState<V>
               if (result is List<V>) newValues = result;
             }
             if (newValues != null) {
-              _selectedItems = newValues;
+              widget.controller.selectedItems = newValues;
               if (widget.state != null) {
-                widget.state!.didChange(_selectedItems);
+                widget.state!.didChange(widget.controller.selectedItems);
               }
             }
           },
@@ -360,7 +366,7 @@ class __MultiSelectDialogFieldViewState<V>
           listType: widget.listType,
           items: widget.items,
           title: widget.title != null ? widget.title : Text("Select"),
-          initialValue: _selectedItems,
+          initialValue: widget.controller.selectedItems,
           searchable: widget.searchable ?? false,
           confirmText: widget.confirmText,
           cancelText: widget.cancelText,
@@ -368,7 +374,7 @@ class __MultiSelectDialogFieldViewState<V>
             if (widget.state != null) {
               widget.state!.didChange(selected);
             }
-            _selectedItems = selected;
+            widget.controller.selectedItems = selected;
             if (widget.onConfirm != null) widget.onConfirm!(selected);
           },
         );
@@ -393,14 +399,14 @@ class __MultiSelectDialogFieldViewState<V>
                         bottom: BorderSide(
                           color: widget.state != null && widget.state!.hasError
                               ? Colors.red.shade800.withOpacity(0.6)
-                              : _selectedItems.isNotEmpty
+                              : widget.controller.selectedItems.isNotEmpty
                                   ? (widget.selectedColor != null &&
                                           widget.selectedColor !=
                                               Colors.transparent)
                                       ? widget.selectedColor!
                                       : Theme.of(context).primaryColor
                                   : Colors.black45,
-                          width: _selectedItems.isNotEmpty
+                          width: widget.controller.selectedItems.isNotEmpty
                               ? (widget.state != null && widget.state!.hasError)
                                   ? 1.4
                                   : 1.8

--- a/lib/dialog/multi_select_dialog_field.dart
+++ b/lib/dialog/multi_select_dialog_field.dart
@@ -39,7 +39,7 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
   final List<V>? initialValue;
 
   /// Fires when confirm is tapped.
-  final void Function(List<V>) onConfirm;
+  final void Function(List<V>)? onConfirm;
 
   /// Toggles search functionality.
   final bool? searchable;
@@ -101,7 +101,7 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
 
   MultiSelectDialogField({
     required this.items,
-    required this.onConfirm,
+    this.onConfirm,
     this.title,
     this.buttonText,
     this.buttonIcon,
@@ -293,48 +293,45 @@ class __MultiSelectDialogFieldViewState<V> extends State<_MultiSelectDialogField
       // if user has specified a chipDisplay, use its params
       if (widget.chipDisplay!.disabled!) {
         return Container();
-      } else {
-        return MultiSelectChipDisplay<V>(
-          items: chipDisplayItems,
-          colorator: widget.chipDisplay!.colorator ?? widget.colorator,
-          onTap: (item) {
-            List<V>? newValues;
-            if (widget.chipDisplay!.onTap != null) {
-              dynamic result = widget.chipDisplay!.onTap!(item);
-              if (result is List<V>) newValues = result;
-            }
-            if (newValues != null) {
-              widget.controller.selectedItems = newValues;
-              if (widget.state != null) {
-                widget.state!.didChange(widget.controller.selectedItems);
-              }
-            }
-          },
-          decoration: widget.chipDisplay!.decoration,
-          chipColor: widget.chipDisplay!.chipColor ??
-              ((widget.selectedColor != null && widget.selectedColor != Colors.transparent)
-                  ? widget.selectedColor!.withOpacity(0.35)
-                  : null),
-          alignment: widget.chipDisplay!.alignment,
-          textStyle: widget.chipDisplay!.textStyle,
-          icon: widget.chipDisplay!.icon,
-          shape: widget.chipDisplay!.shape,
-          scroll: widget.chipDisplay!.scroll,
-          scrollBar: widget.chipDisplay!.scrollBar,
-          height: widget.chipDisplay!.height,
-          chipWidth: widget.chipDisplay!.chipWidth,
-        );
       }
-    } else {
-      // user didn't specify a chipDisplay, build the default
       return MultiSelectChipDisplay<V>(
         items: chipDisplayItems,
-        colorator: widget.colorator,
-        chipColor: (widget.selectedColor != null && widget.selectedColor != Colors.transparent)
-            ? widget.selectedColor!.withOpacity(0.35)
-            : null,
+        colorator: widget.chipDisplay!.colorator ?? widget.colorator,
+        onTap: (item) {
+          if (widget.chipDisplay!.onTap != null) {
+            // if you have a function, tell me about the new list
+            List<V> newList = widget.chipDisplay!.onTap!(item);
+            widget.controller.selectedItems = newList;
+          } else {
+            widget.controller.selectedItems.remove(item);
+          }
+          if (widget.state != null) {
+            widget.state!.didChange(widget.controller.selectedItems);
+          }
+        },
+        decoration: widget.chipDisplay!.decoration,
+        chipColor: widget.chipDisplay!.chipColor ??
+            ((widget.selectedColor != null && widget.selectedColor != Colors.transparent)
+                ? widget.selectedColor!.withOpacity(0.35)
+                : null),
+        alignment: widget.chipDisplay!.alignment,
+        textStyle: widget.chipDisplay!.textStyle,
+        icon: widget.chipDisplay!.icon,
+        shape: widget.chipDisplay!.shape,
+        scroll: widget.chipDisplay!.scroll,
+        scrollBar: widget.chipDisplay!.scrollBar,
+        height: widget.chipDisplay!.height,
+        chipWidth: widget.chipDisplay!.chipWidth,
       );
     }
+    // user didn't specify a chipDisplay, build the default
+    return MultiSelectChipDisplay<V>(
+      items: chipDisplayItems,
+      colorator: widget.colorator,
+      chipColor: (widget.selectedColor != null && widget.selectedColor != Colors.transparent)
+          ? widget.selectedColor!.withOpacity(0.35)
+          : null,
+    );
   }
 
   /// Calls showDialog() and renders a MultiSelectDialog.

--- a/lib/dialog/multi_select_dialog_field.dart
+++ b/lib/dialog/multi_select_dialog_field.dart
@@ -1,5 +1,6 @@
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter/material.dart';
+import '../util/multi_select_dialog_field_controller.dart';
 import '../util/multi_select_list_type.dart';
 import '../util/multi_select_item.dart';
 import '../chip_display/multi_select_chip_display.dart';

--- a/lib/dialog/multi_select_dialog_field.dart
+++ b/lib/dialog/multi_select_dialog_field.dart
@@ -167,7 +167,7 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
                 searchHintStyle: searchHintStyle,
                 selectedItemsTextStyle: selectedItemsTextStyle,
                 checkColor: checkColor,
-                controller: controller ?? MultiSelectDialogFieldController<V>(),
+                controller: controller,
               );
               return _MultiSelectDialogFieldView<V?>._withState(
                   field as _MultiSelectDialogFieldView<V?>, state);
@@ -204,7 +204,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
   final TextStyle? searchHintStyle;
   final Color? checkColor;
   FormFieldState<List<V>>? state;
-  MultiSelectDialogFieldController<V> controller;
+  MultiSelectDialogFieldController<V>? controller;
 
   _MultiSelectDialogFieldView({
     required this.items,
@@ -275,17 +275,23 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
 }
 
 class __MultiSelectDialogFieldViewState<V> extends State<_MultiSelectDialogFieldView<V>> {
+  final MultiSelectDialogFieldController<V> internalCtrl = MultiSelectDialogFieldController<V>();
+
+  MultiSelectDialogFieldController<V> get controller {
+    return widget.controller ?? internalCtrl;
+  }
+
   void initState() {
     super.initState();
 
     if (widget.initialValue != null) {
-      widget.controller.selectedItems.addAll(widget.initialValue!);
+      controller.selectedItems.addAll(widget.initialValue!);
     }
   }
 
   Widget _buildInheritedChipDisplay() {
     List<MultiSelectItem<V>?> chipDisplayItems = [];
-    chipDisplayItems = widget.controller.selectedItems
+    chipDisplayItems = controller.selectedItems
         .map((e) => widget.items.firstWhereOrNull((element) => e == element.value))
         .toList();
     chipDisplayItems.removeWhere((element) => element == null);
@@ -301,12 +307,12 @@ class __MultiSelectDialogFieldViewState<V> extends State<_MultiSelectDialogField
           if (widget.chipDisplay!.onTap != null) {
             // if you have a function, tell me about the new list
             List<V> newList = widget.chipDisplay!.onTap!(item);
-            widget.controller.selectedItems = newList;
+            controller.selectedItems = newList;
           } else {
-            widget.controller.selectedItems.remove(item);
+            controller.selectedItems.remove(item);
           }
           if (widget.state != null) {
-            widget.state!.didChange(widget.controller.selectedItems);
+            widget.state!.didChange(controller.selectedItems);
           }
         },
         decoration: widget.chipDisplay!.decoration,
@@ -358,7 +364,7 @@ class __MultiSelectDialogFieldViewState<V> extends State<_MultiSelectDialogField
           listType: widget.listType,
           items: widget.items,
           title: widget.title != null ? widget.title : Text("Select"),
-          initialValue: widget.controller.selectedItems,
+          initialValue: controller.selectedItems,
           searchable: widget.searchable ?? false,
           confirmText: widget.confirmText,
           cancelText: widget.cancelText,
@@ -366,7 +372,7 @@ class __MultiSelectDialogFieldViewState<V> extends State<_MultiSelectDialogField
             if (widget.state != null) {
               widget.state!.didChange(selected);
             }
-            widget.controller.selectedItems = selected;
+            controller.selectedItems = selected;
             if (widget.onConfirm != null) widget.onConfirm!(selected);
           },
         );
@@ -391,13 +397,13 @@ class __MultiSelectDialogFieldViewState<V> extends State<_MultiSelectDialogField
                         bottom: BorderSide(
                           color: widget.state != null && widget.state!.hasError
                               ? Colors.red.shade800.withOpacity(0.6)
-                              : widget.controller.selectedItems.isNotEmpty
+                              : controller.selectedItems.isNotEmpty
                                   ? (widget.selectedColor != null &&
                                           widget.selectedColor != Colors.transparent)
                                       ? widget.selectedColor!
                                       : Theme.of(context).primaryColor
                                   : Colors.black45,
-                          width: widget.controller.selectedItems.isNotEmpty
+                          width: controller.selectedItems.isNotEmpty
                               ? (widget.state != null && widget.state!.hasError)
                                   ? 1.4
                                   : 1.8
@@ -417,23 +423,23 @@ class __MultiSelectDialogFieldViewState<V> extends State<_MultiSelectDialogField
           ),
         ),
         _buildInheritedChipDisplay(),
-        widget.state != null && widget.state!.hasError ? SizedBox(height: 5) : Container(),
-        widget.state != null && widget.state!.hasError
-            ? Row(
-                children: <Widget>[
-                  Padding(
-                    padding: const EdgeInsets.only(left: 4),
-                    child: Text(
-                      widget.state!.errorText!,
-                      style: TextStyle(
-                        color: Colors.red[800],
-                        fontSize: 12.5,
-                      ),
-                    ),
+        if (widget.state != null && widget.state!.hasError) ...[
+          SizedBox(height: 5),
+          Row(
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.only(left: 4),
+                child: Text(
+                  widget.state!.errorText!,
+                  style: TextStyle(
+                    color: Colors.red[800],
+                    fontSize: 12.5,
                   ),
-                ],
-              )
-            : Container(),
+                ),
+              ),
+            ],
+          ),
+        ]
       ],
     );
   }

--- a/lib/dialog/multi_select_dialog_field.dart
+++ b/lib/dialog/multi_select_dialog_field.dart
@@ -170,7 +170,7 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
                 searchHintStyle: searchHintStyle,
                 selectedItemsTextStyle: selectedItemsTextStyle,
                 checkColor: checkColor,
-                controller: controller,
+                controller: controller ?? MultiSelectDialogFieldController<V>(),
               );
               return _MultiSelectDialogFieldView<V?>._withState(
                   field as _MultiSelectDialogFieldView<V?>, state);
@@ -207,7 +207,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
   final TextStyle? searchHintStyle;
   final Color? checkColor;
   FormFieldState<List<V>>? state;
-  MultiSelectDialogFieldController<V>? controller;
+  MultiSelectDialogFieldController<V> controller;
 
   _MultiSelectDialogFieldView({
     required this.items,
@@ -237,7 +237,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
     this.searchHintStyle,
     this.selectedItemsTextStyle,
     this.checkColor,
-    this.controller,
+    required this.controller,
   });
 
   /// This constructor allows a FormFieldState to be passed in. Called by MultiSelectDialogField.
@@ -280,18 +280,15 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
 class __MultiSelectDialogFieldViewState<V> extends State<_MultiSelectDialogFieldView<V>> {
   void initState() {
     super.initState();
-    if (widget.controller == null) {
-      widget.controller = MultiSelectDialogFieldController<V>();
-    }
 
     if (widget.initialValue != null) {
-      widget.controller!.selectedItems.addAll(widget.initialValue!);
+      widget.controller.selectedItems.addAll(widget.initialValue!);
     }
   }
 
   Widget _buildInheritedChipDisplay() {
     List<MultiSelectItem<V>?> chipDisplayItems = [];
-    chipDisplayItems = widget.controller!.selectedItems
+    chipDisplayItems = widget.controller.selectedItems
         .map((e) => widget.items.firstWhereOrNull((element) => e == element.value))
         .toList();
     chipDisplayItems.removeWhere((element) => element == null);
@@ -310,9 +307,9 @@ class __MultiSelectDialogFieldViewState<V> extends State<_MultiSelectDialogField
               if (result is List<V>) newValues = result;
             }
             if (newValues != null) {
-              widget.controller!.selectedItems = newValues;
+              widget.controller.selectedItems = newValues;
               if (widget.state != null) {
-                widget.state!.didChange(widget.controller!.selectedItems);
+                widget.state!.didChange(widget.controller.selectedItems);
               }
             }
           },
@@ -367,7 +364,7 @@ class __MultiSelectDialogFieldViewState<V> extends State<_MultiSelectDialogField
           listType: widget.listType,
           items: widget.items,
           title: widget.title != null ? widget.title : Text("Select"),
-          initialValue: widget.controller!.selectedItems,
+          initialValue: widget.controller.selectedItems,
           searchable: widget.searchable ?? false,
           confirmText: widget.confirmText,
           cancelText: widget.cancelText,
@@ -375,7 +372,7 @@ class __MultiSelectDialogFieldViewState<V> extends State<_MultiSelectDialogField
             if (widget.state != null) {
               widget.state!.didChange(selected);
             }
-            widget.controller!.selectedItems = selected;
+            widget.controller.selectedItems = selected;
             if (widget.onConfirm != null) widget.onConfirm!(selected);
           },
         );
@@ -400,13 +397,13 @@ class __MultiSelectDialogFieldViewState<V> extends State<_MultiSelectDialogField
                         bottom: BorderSide(
                           color: widget.state != null && widget.state!.hasError
                               ? Colors.red.shade800.withOpacity(0.6)
-                              : widget.controller!.selectedItems.isNotEmpty
+                              : widget.controller.selectedItems.isNotEmpty
                                   ? (widget.selectedColor != null &&
                                           widget.selectedColor != Colors.transparent)
                                       ? widget.selectedColor!
                                       : Theme.of(context).primaryColor
                                   : Colors.black45,
-                          width: widget.controller!.selectedItems.isNotEmpty
+                          width: widget.controller.selectedItems.isNotEmpty
                               ? (widget.state != null && widget.state!.hasError)
                                   ? 1.4
                                   : 1.8

--- a/lib/dialog/multi_select_dialog_field.dart
+++ b/lib/dialog/multi_select_dialog_field.dart
@@ -99,9 +99,6 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
   final GlobalKey<FormFieldState>? key;
   FormFieldState<List<V>>? state;
 
-  /// Controller for programmatically change selected items
-  final MultiSelectDialogFieldController<V>? controller;
-
   MultiSelectDialogField({
     required this.items,
     required this.onConfirm,
@@ -133,7 +130,7 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
     this.validator,
     this.initialValue,
     this.autovalidateMode = AutovalidateMode.disabled,
-    this.controller,
+    MultiSelectDialogFieldController<V>? controller,
     this.key,
   }) : super(
             key: key,

--- a/lib/multi_select_flutter.dart
+++ b/lib/multi_select_flutter.dart
@@ -1,10 +1,11 @@
-export 'util/multi_select_item.dart';
-export 'util/multi_select_list_type.dart';
-export 'util/multi_select_actions.dart';
-export 'dialog/mult_select_dialog.dart';
-export 'dialog/multi_select_dialog_field.dart';
 export 'bottom_sheet/multi_select_bottom_sheet.dart';
 export 'bottom_sheet/multi_select_bottom_sheet_field.dart';
 export 'chip_display/multi_select_chip_display.dart';
 export 'chip_field/multi_select_chip_field.dart';
+export 'dialog/mult_select_dialog.dart';
+export 'dialog/multi_select_dialog_field.dart';
 export 'util/horizontal_scrollbar.dart';
+export 'util/multi_select_actions.dart';
+export 'util/multi_select_dialog_field_controller.dart';
+export 'util/multi_select_item.dart';
+export 'util/multi_select_list_type.dart';

--- a/lib/util/multi_select_dialog_field_controller.dart
+++ b/lib/util/multi_select_dialog_field_controller.dart
@@ -1,0 +1,3 @@
+class MultiSelectDialogFieldController<V> {
+  List<V> selectedItems = [];
+}


### PR DESCRIPTION
This should fix #12, maybe #68 (I think so but it's debatable), and be back-compatible.

Basically, I added a controller class that can be controller from outside of the widget itself, allowing the developer, as shown in the example app, to add a clear button, for example.