### PR TITLE
Fixing an overflow in modal/bottom sheet title

### DIFF
--- a/lib/bottom_sheet/multi_select_bottom_sheet.dart
+++ b/lib/bottom_sheet/multi_select_bottom_sheet.dart
@@ -247,11 +247,13 @@ class _MultiSelectBottomSheetState<V> extends State<MultiSelectBottomSheet<V>> {
                               ),
                             ),
                           )
-                        : widget.title ??
-                            Text(
-                              "Select",
-                              style: TextStyle(fontSize: 18),
-                            ),
+                        : Expanded(
+                            child: widget.title ??
+                                Text(
+                                  "Select",
+                                  style: TextStyle(fontSize: 18),
+                                ),
+                        ),
                     widget.searchable != null && widget.searchable!
                         ? IconButton(
                             icon: _showSearch

--- a/lib/dialog/mult_select_dialog.dart
+++ b/lib/dialog/mult_select_dialog.dart
@@ -233,7 +233,9 @@ class _MultiSelectDialogState<V> extends State<MultiSelectDialog<V>> {
                             ),
                           ),
                         )
-                      : widget.title ?? Text("Select"),
+                      : Expanded(
+                          child: widget.title ?? Text("Select"),
+                      ),
                   IconButton(
                     icon: _showSearch
                         ? widget.closeSearchIcon ?? Icon(Icons.close)


### PR DESCRIPTION
If the title provided to `MultiSelectDialog` or `MultiSelectBottomSheet` is too long it can become too long to fit in the space it gets. Since it is rendered inside a `Row` it is easily fixed by wrapping the title in `Expanded`.

This should prevent overflow and ensure that the title gets correctly laid out in its designated space.