### PR TITLE
I removed "!" from the instance property, because since the Flutter 3.00

### DIFF
--- a/lib/chip_field/multi_select_chip_field.dart
+++ b/lib/chip_field/multi_select_chip_field.dart
@@ -270,7 +270,7 @@ class __MultiSelectChipFieldViewState<V>
       _selectedValues.addAll(widget.initialValue!);
     }
     if (widget.scrollControl != null && widget.scroll)
-      WidgetsBinding.instance!.addPostFrameCallback((_) => _scrollToPosition());
+      WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToPosition());
   }
 
   _scrollToPosition() {


### PR DESCRIPTION
the instance getter will not return null anymore. As you can see here: binding.dart#L304 The commit associated with this change is this one: ab89ce285f76a3fd3a9328ec863f5623cc5ac8bc