### PR TITLE
Added readOnly feature for MultiSelectDialogField and MultiSelectBottomSheetField

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ MultiSelectDialogField has all the parameters of MultiSelectDialog plus these ex
 | `decoration` | BoxDecoration | Style the Container that makes up the field. |
 | `key` | GlobalKey\<FormFieldState> | Access FormFieldState methods. |
 | `onSaved` | List\<MultiSelectItem> | A callback that is called whenever we submit the field (usually by calling the `save` method on a form. |
+| `readOnly` | bool | If enabled, the MultiSelectDialogField will be readOnly. Default value is `false` |
 | `validator` | FormFieldValidator\<List> | Validation. See [Flutter's documentation](https://flutter.dev/docs/cookbook/forms/validation). |
 
 ### MultiSelectBottomSheet
@@ -261,6 +262,7 @@ MultiSelectBottomSheetField has all the parameters of MultiSelectBottomSheet plu
 | `key` | GlobalKey\<FormFieldState> | Can be used to call methods like `_multiSelectKey.currentState.validate()`. |
 | `onSaved` | List\<MultiSelectItem> | A callback that is called whenever we submit the field (usually by calling the `save` method on a form. |
 | `shape` | ShapeBorder | Apply a ShapeBorder to alter the edges of the BottomSheet. Default is a RoundedRectangleBorder with top circular radius of 15. |
+| `readOnly` | bool | If enabled, the MultiSelectBottomSheetField will be readOnly. Default value is `false` |
 | `validator` | FormFieldValidator\<List> | Validation. See [Flutter's documentation](https://flutter.dev/docs/cookbook/forms/validation). |
 
 ### MultiSelectChipField

--- a/lib/bottom_sheet/multi_select_bottom_sheet_field.dart
+++ b/lib/bottom_sheet/multi_select_bottom_sheet_field.dart
@@ -103,6 +103,9 @@ class MultiSelectBottomSheetField<V> extends FormField<List<V>> {
   /// Set the color of the check in the checkbox
   final Color? checkColor;
 
+  /// Bool to set the multi-select-dialog-field readOnly
+  final bool readOnly;
+
   final AutovalidateMode autovalidateMode;
   final FormFieldValidator<List<V>>? validator;
   final FormFieldSetter<List<V>>? onSaved;
@@ -145,6 +148,7 @@ class MultiSelectBottomSheetField<V> extends FormField<List<V>> {
     this.onSaved,
     this.validator,
     this.autovalidateMode = AutovalidateMode.disabled,
+    this.readOnly = false
   }) : super(
             key: key,
             onSaved: onSaved,
@@ -185,6 +189,7 @@ class MultiSelectBottomSheetField<V> extends FormField<List<V>> {
                 separateSelectedItems: separateSelectedItems,
                 shape: shape,
                 checkColor: checkColor,
+                readOnly: readOnly
               );
               return _MultiSelectBottomSheetFieldView<V?>._withState(
                   view as _MultiSelectBottomSheetFieldView<V?>, state);
@@ -224,6 +229,7 @@ class _MultiSelectBottomSheetFieldView<V> extends StatefulWidget {
   final TextStyle? searchHintStyle;
   final bool separateSelectedItems;
   final Color? checkColor;
+  final bool readOnly;
   FormFieldState<List<V>>? state;
 
   _MultiSelectBottomSheetFieldView({
@@ -258,6 +264,7 @@ class _MultiSelectBottomSheetFieldView<V> extends StatefulWidget {
     this.selectedItemsTextStyle,
     this.separateSelectedItems = false,
     this.checkColor,
+    this.readOnly = false,
   });
 
   /// This constructor allows a FormFieldState to be passed in. Called by MultiSelectBottomSheetField.
@@ -294,6 +301,7 @@ class _MultiSelectBottomSheetFieldView<V> extends StatefulWidget {
         selectedItemsTextStyle = field.selectedItemsTextStyle,
         separateSelectedItems = field.separateSelectedItems,
         checkColor = field.checkColor,
+        readOnly = field.readOnly,
         state = state;
 
   @override
@@ -423,7 +431,9 @@ class __MultiSelectBottomSheetFieldViewState<V>
       children: <Widget>[
         InkWell(
           onTap: () {
-            _showBottomSheet(context);
+            if (!widget.readOnly) {
+              _showBottomSheet(context);
+            }
           },
           child: Container(
             decoration: widget.state != null

--- a/lib/dialog/multi_select_dialog_field.dart
+++ b/lib/dialog/multi_select_dialog_field.dart
@@ -97,6 +97,9 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
   /// Set the color of the check in the checkbox
   final Color? checkColor;
 
+  /// Bool to set the multi-select-dialog-field readOnly
+  final bool readOnly;
+
   final AutovalidateMode autovalidateMode;
   final FormFieldValidator<List<V>>? validator;
   final FormFieldSetter<List<V>>? onSaved;
@@ -137,6 +140,7 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
     this.initialValue,
     this.autovalidateMode = AutovalidateMode.disabled,
     this.key,
+    this.readOnly = false
   }) : super(
             key: key,
             onSaved: onSaved,
@@ -175,6 +179,7 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
                 selectedItemsTextStyle: selectedItemsTextStyle,
                 separateSelectedItems: separateSelectedItems,
                 checkColor: checkColor,
+                readOnly: readOnly
               );
               return _MultiSelectDialogFieldView<V>._withState(field, state);
             });
@@ -211,6 +216,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
   final TextStyle? searchHintStyle;
   final bool separateSelectedItems;
   final Color? checkColor;
+  final bool readOnly;
   FormFieldState<List<V>>? state;
 
   _MultiSelectDialogFieldView({
@@ -243,6 +249,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
     this.selectedItemsTextStyle,
     this.separateSelectedItems = false,
     this.checkColor,
+    this.readOnly = false
   });
 
   /// This constructor allows a FormFieldState to be passed in. Called by MultiSelectDialogField.
@@ -277,6 +284,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
         selectedItemsTextStyle = field.selectedItemsTextStyle,
         separateSelectedItems = field.separateSelectedItems,
         checkColor = field.checkColor,
+        readOnly = field.readOnly,
         state = state;
 
   @override
@@ -402,7 +410,9 @@ class __MultiSelectDialogFieldViewState<V>
       children: <Widget>[
         InkWell(
           onTap: () {
-            _showDialog(context);
+            if (!widget.readOnly) {
+              _showDialog(context);
+            }
           },
           child: Container(
             decoration: widget.state != null


### PR DESCRIPTION
Added readOnly feature for MultiSelectDialogField and MultiSelectBottomSheetField so that the users may set the initial values  but will not be able to select any new values for the MultiSelectDialogField and MultiSelectBottomSheetField