### PR TITLE
Update multi_select_chip_field.dart

### DIFF
--- a/lib/chip_field/multi_select_chip_field.dart
+++ b/lib/chip_field/multi_select_chip_field.dart
@@ -270,7 +270,7 @@ class __MultiSelectChipFieldViewState<V>
       _selectedValues.addAll(widget.initialValue!);
     }
     if (widget.scrollControl != null && widget.scroll)
-      WidgetsBinding.instance!.addPostFrameCallback((_) => _scrollToPosition());
+      WidgetsBinding.instance.addPostFrameCallback((_) => _scrollToPosition());
   }
 
   _scrollToPosition() {


### PR DESCRIPTION
In flutter 3 WidgetsBinding excludes null
Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null