### PR TITLE
Add maxSelectedItems and reverseActions support for MultiSelectDialogField

### DIFF
--- a/lib/dialog/mult_select_dialog.dart
+++ b/lib/dialog/mult_select_dialog.dart
@@ -78,6 +78,9 @@ class MultiSelectDialog<T> extends StatefulWidget with MultiSelectActions<T> {
   /// Set the color of the check in the checkbox
   final Color? checkColor;
 
+  /// The maximum number of items that can be selected
+  final int? maxSelectedItems;
+
   MultiSelectDialog({
     required this.items,
     required this.initialValue,
@@ -103,6 +106,7 @@ class MultiSelectDialog<T> extends StatefulWidget with MultiSelectActions<T> {
     this.selectedItemsTextStyle,
     this.separateSelectedItems = false,
     this.checkColor,
+    this.maxSelectedItems,
   });
 
   @override
@@ -197,6 +201,12 @@ class _MultiSelectDialogState<T> extends State<MultiSelectDialog<T>> {
         ),
         selected: item.selected,
         onSelected: (checked) {
+          if (widget.maxSelectedItems != null && widget.maxSelectedItems == 1) {
+            for (int i = 0; i < _items.length; i++) {
+              _items[i].selected = false;
+            }
+            _selectedValues = [];
+          }
           if (checked) {
             item.selected = true;
           } else {

--- a/lib/dialog/mult_select_dialog.dart
+++ b/lib/dialog/mult_select_dialog.dart
@@ -205,11 +205,20 @@ class _MultiSelectDialogState<T> extends State<MultiSelectDialog<T>> {
         ),
         selected: item.selected,
         onSelected: (checked) {
-          if (widget.maxSelectedItems != null && widget.maxSelectedItems == 1) {
-            for (int i = 0; i < _items.length; i++) {
-              _items[i].selected = false;
-            }
-            _selectedValues = [];
+          int selectedItems = _selectedValues.length;
+          if (checked) {
+            selectedItems++;
+          } else {
+            selectedItems--;
+          }
+
+          if (widget.maxSelectedItems != null &&
+              selectedItems > widget.maxSelectedItems!) {
+            T _removedValue = _selectedValues.removeAt(0);
+            MultiSelectItem<T> _value =
+                _items.firstWhere((element) => element.value == _removedValue);
+
+            _value.selected = false;
           }
           if (checked) {
             item.selected = true;

--- a/lib/dialog/mult_select_dialog.dart
+++ b/lib/dialog/mult_select_dialog.dart
@@ -81,6 +81,9 @@ class MultiSelectDialog<T> extends StatefulWidget with MultiSelectActions<T> {
   /// The maximum number of items that can be selected
   final int? maxSelectedItems;
 
+  /// Reverse the order of the confirm and cancel buttons
+  final bool reverseActions;
+
   MultiSelectDialog({
     required this.items,
     required this.initialValue,
@@ -107,6 +110,7 @@ class MultiSelectDialog<T> extends StatefulWidget with MultiSelectActions<T> {
     this.separateSelectedItems = false,
     this.checkColor,
     this.maxSelectedItems,
+    this.reverseActions = false,
   });
 
   @override
@@ -306,38 +310,46 @@ class _MultiSelectDialogState<T> extends State<MultiSelectDialog<T>> {
                 ),
               ),
       ),
-      actions: <Widget>[
-        TextButton(
-          child: widget.cancelText ??
-              Text(
-                "CANCEL",
-                style: TextStyle(
-                  color: (widget.selectedColor != null &&
-                          widget.selectedColor != Colors.transparent)
-                      ? widget.selectedColor!.withOpacity(1)
-                      : Theme.of(context).primaryColor,
+      actions: () {
+        List<Widget> actions = [
+          TextButton(
+            child: widget.cancelText ??
+                Text(
+                  "CANCEL",
+                  style: TextStyle(
+                    color: (widget.selectedColor != null &&
+                            widget.selectedColor != Colors.transparent)
+                        ? widget.selectedColor!.withOpacity(1)
+                        : Theme.of(context).primaryColor,
+                  ),
                 ),
-              ),
-          onPressed: () {
-            widget.onCancelTap(context, widget.initialValue);
-          },
-        ),
-        TextButton(
-          child: widget.confirmText ??
-              Text(
-                'OK',
-                style: TextStyle(
-                  color: (widget.selectedColor != null &&
-                          widget.selectedColor != Colors.transparent)
-                      ? widget.selectedColor!.withOpacity(1)
-                      : Theme.of(context).primaryColor,
+            onPressed: () {
+              widget.onCancelTap(context, widget.initialValue);
+            },
+          ),
+          TextButton(
+            child: widget.confirmText ??
+                Text(
+                  'OK',
+                  style: TextStyle(
+                    color: (widget.selectedColor != null &&
+                            widget.selectedColor != Colors.transparent)
+                        ? widget.selectedColor!.withOpacity(1)
+                        : Theme.of(context).primaryColor,
+                  ),
                 ),
-              ),
-          onPressed: () {
-            widget.onConfirmTap(context, _selectedValues, widget.onConfirm);
-          },
-        )
-      ],
+            onPressed: () {
+              widget.onConfirmTap(context, _selectedValues, widget.onConfirm);
+            },
+          )
+        ];
+
+        if (widget.reverseActions) {
+          actions = actions.reversed.toList();
+        }
+
+        return actions;
+      }(),
     );
   }
 }

--- a/lib/dialog/multi_select_dialog_field.dart
+++ b/lib/dialog/multi_select_dialog_field.dart
@@ -100,6 +100,9 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
   /// Whether the user can dismiss the widget by tapping outside
   final bool isDismissible;
 
+  /// The maximum number of items that can be selected
+  final int? maxSelectedItems;
+
   final AutovalidateMode autovalidateMode;
   final FormFieldValidator<List<V>>? validator;
   final FormFieldSetter<List<V>>? onSaved;
@@ -141,6 +144,7 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
     this.initialValue = const [],
     this.autovalidateMode = AutovalidateMode.disabled,
     this.key,
+    this.maxSelectedItems,
   }) : super(
             key: key,
             onSaved: onSaved,
@@ -180,6 +184,7 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
                 separateSelectedItems: separateSelectedItems,
                 checkColor: checkColor,
                 isDismissible: isDismissible,
+                maxSelectedItems: maxSelectedItems,
               );
               return _MultiSelectDialogFieldView<V>._withState(field, state);
             });
@@ -218,6 +223,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
   final Color? checkColor;
   final bool isDismissible;
   FormFieldState<List<V>>? state;
+  final int? maxSelectedItems;
 
   _MultiSelectDialogFieldView({
     required this.items,
@@ -250,6 +256,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
     this.separateSelectedItems = false,
     this.checkColor,
     required this.isDismissible,
+    this.maxSelectedItems,
   });
 
   /// This constructor allows a FormFieldState to be passed in. Called by MultiSelectDialogField.
@@ -285,6 +292,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
         separateSelectedItems = field.separateSelectedItems,
         checkColor = field.checkColor,
         isDismissible = field.isDismissible,
+        maxSelectedItems = field.maxSelectedItems,
         state = state;
 
   @override
@@ -411,6 +419,7 @@ class __MultiSelectDialogFieldViewState<V>
             }
             if (widget.onConfirm != null) widget.onConfirm!(_selectedItems);
           },
+          maxSelectedItems: widget.maxSelectedItems,
         );
       },
     );

--- a/lib/dialog/multi_select_dialog_field.dart
+++ b/lib/dialog/multi_select_dialog_field.dart
@@ -103,6 +103,9 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
   /// The maximum number of items that can be selected
   final int? maxSelectedItems;
 
+  /// Reverse the order of the confirm and cancel buttons
+  final bool reverseActions;
+
   final AutovalidateMode autovalidateMode;
   final FormFieldValidator<List<V>>? validator;
   final FormFieldSetter<List<V>>? onSaved;
@@ -145,6 +148,7 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
     this.autovalidateMode = AutovalidateMode.disabled,
     this.key,
     this.maxSelectedItems,
+    this.reverseActions = false,
   }) : super(
             key: key,
             onSaved: onSaved,
@@ -185,6 +189,7 @@ class MultiSelectDialogField<V> extends FormField<List<V>> {
                 checkColor: checkColor,
                 isDismissible: isDismissible,
                 maxSelectedItems: maxSelectedItems,
+                reverseActions: reverseActions,
               );
               return _MultiSelectDialogFieldView<V>._withState(field, state);
             });
@@ -224,6 +229,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
   final bool isDismissible;
   FormFieldState<List<V>>? state;
   final int? maxSelectedItems;
+  final bool reverseActions;
 
   _MultiSelectDialogFieldView({
     required this.items,
@@ -257,6 +263,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
     this.checkColor,
     required this.isDismissible,
     this.maxSelectedItems,
+    this.reverseActions = false,
   });
 
   /// This constructor allows a FormFieldState to be passed in. Called by MultiSelectDialogField.
@@ -293,6 +300,7 @@ class _MultiSelectDialogFieldView<V> extends StatefulWidget {
         checkColor = field.checkColor,
         isDismissible = field.isDismissible,
         maxSelectedItems = field.maxSelectedItems,
+        reverseActions = field.reverseActions,
         state = state;
 
   @override
@@ -420,6 +428,7 @@ class __MultiSelectDialogFieldViewState<V>
             if (widget.onConfirm != null) widget.onConfirm!(_selectedItems);
           },
           maxSelectedItems: widget.maxSelectedItems,
+          reverseActions: widget.reverseActions,
         );
       },
     );


### PR DESCRIPTION
**Overview:**

Users may want to limit the selected items for some fields without using other package.

By default maxSelectedItems is null which means there is not selection limit.

This only add support for MultiSelectDialogField because is the field I use for my personal project.

Also some users may want to change the OK and CANCEL button order for the multi select dialog, so I introduced reverseActions which is false by default.

**Example:**

```
MultiSelectDialogField<T>(
    title: Text(title),
    buttonText: Text(
      buttonText,
      style: TextStyle(
        color: Colors.black54,
      ),
    ),
    initialValue: initialValue,
    items: items,
    listType: MultiSelectListType.CHIP,
    onConfirm: onConfirm,
    selectedItemsTextStyle: const TextStyle(
      color: kWhiteColor,
    ),
    selectedColor: kHempColor,
    buttonIcon: const Icon(
      Icons.edit,
      color: Colors.black54,
    ),
    maxSelectedItems: 1,
    reverseActions: true,
  )
``` 

**How to test before is merge**

Add to your pubspec.yaml
```
dependencies:
  flutter:
    sdk: flutter

  multi_select_flutter:
      git:
        url: https://github.com/ingmferrer/multi_select_flutter.git
        ref: master
```