### PR TITLE
Preserve selected state when filtering items during search

### DIFF
--- a/lib/dialog/mult_select_dialog.dart
+++ b/lib/dialog/mult_select_dialog.dart
@@ -243,6 +243,9 @@ class _MultiSelectDialogState<T> extends State<MultiSelectDialog<T>> {
                               List<MultiSelectItem<T>> filteredList = [];
                               filteredList =
                                   widget.updateSearchQuery(val, widget.items);
+                              for (var item in filteredList) {
+                                item.selected = _selectedValues.contains(item.value);
+                              }
                               setState(() {
                                 if (widget.separateSelectedItems) {
                                   _items =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: multi_select_flutter
 description: A flexible multi select package for Flutter. Make multi select widgets the way you want.
-version: 4.1.3
+version: 4.1.4
 repository: https://github.com/CHB61/flutter-multi-select
 issue_tracker: https://github.com/CHB61/flutter-multi-select
 documentation: https://github.com/CHB61/flutter-multi-select


### PR DESCRIPTION
The existing search implementation rebuilt the item list without reapplying selection flags, causing previously selected items to appear unselected in filtered search results. This commit ensures that MultiSelectItem.selected is recalculated based on selectedValues after each search update.

Improves UX in MultiSelectDialog by maintaining correct selection state during real-time filtering.